### PR TITLE
hardware: sg13g2: Fix missing IOVSS+IOVDD

### DIFF
--- a/.github/workflows/run-design.yaml
+++ b/.github/workflows/run-design.yaml
@@ -5,8 +5,8 @@ on:
     branches: [ main ]
     paths:
       - 'build.sbt'
-      - '.github/'
-      - 'hardware/'
+      - '.github/**'
+      - 'hardware/**'
       - 'manifest.xml'
       - 'podmnan-compose*yml'
       - 'Taskfile.yml'

--- a/hardware/scala/i2cgpioexpander/SG13G2/SG13G2.scala
+++ b/hardware/scala/i2cgpioexpander/SG13G2/SG13G2.scala
@@ -82,8 +82,8 @@ object SG13G2Generate extends ElementsApp {
     val io = OpenROADTools.IHP.Io(elementsConfig)
     io.addPad("east", 0, "sg13g2_IOPadVdd")
     io.addPad("east", 1, "sg13g2_IOPadVss")
-    io.addPad("west", 3, "sg13g2_IOPadVss")
-    io.addPad("west", 4, "sg13g2_IOPadVdd")
+    io.addPad("west", 3, "sg13g2_IOPadIOVss")
+    io.addPad("west", 4, "sg13g2_IOPadIOVdd")
     io.generate(top.io)
 
     val pdn = OpenROADTools.IHP.Pdn(elementsConfig)


### PR DESCRIPTION
The design includes twice the number of VDD and VSS pads but lacks IOVSS and IOVDD pads. Convert the duplicated VDD and VSS pins into IOVDD/IOVSS.