### PR TITLE
Add Support for ihp-sg13cmos5l

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -16,9 +16,7 @@ env:
   FPGA_PACKAGE: CABGA554
   FPGA_FREQUENCY: 50
   OPENFPGALOADER_BOARD: ecpix5_r03
-  PDK: ihp-sg13g2
   PDK_ROOT: "{{ .PWD }}/pdks/IHP-Open-PDK/"
-  KLAYOUT_HOME: "{{ .PWD }}/pdks/IHP-Open-PDK/ihp-sg13g2/libs.tech/klayout/"
   NAFARR_BASE: "{{ .PWD }}/modules/elements/nafarr/"
   ZIBAL_BASE: "{{ .PWD }}/modules/elements/zibal/"
   BUILD_ROOT: "{{ .PWD }}/build/"
@@ -26,8 +24,12 @@ env:
 
 vars:
   SOC: '{{.SOC | default "I2cGpioExpander"}}'
+  TECH: '{{.TECH | default "SG13G2"}}'
   package:
     sh: echo "{{.SOC}}" | tr '[:upper:]' '[:lower:]' | tr '-' '_'
+  PDK:
+    sh: echo "ihp-{{.TECH}}" | tr '[:upper:]' '[:lower:]'
+  KLAYOUT_HOME: "{{.PWD}}/pdks/IHP-Open-PDK/{{.PDK}}/libs.tech/klayout/"
   CONTAINER_NAME: i2c-gpio-expander_container
   CONTAINER_ENV: " \
     -e SOC={{ .SOC }} \
@@ -109,73 +111,80 @@ tasks:
     cmds:
       - task: lib-generate
         vars:
-          board: "SG13G2"
+          board: "{{.TECH}}"
       - task: lib-sealring
         vars:
-          board: "SG13G2"
+          board: "{{.TECH}}"
+      - "mkdir -p {{ .BUILD_ROOT }}/{{ .SOC }}/{{ .board }}/zibal/macros/bondpad"
+      - "cp {{.OPENROAD_FLOW_ROOT}}/platforms/ihp-sg13g2/lef/bondpad_70x70.lef {{ .BUILD_ROOT }}/{{ .SOC }}/{{ .board }}/zibal/macros/bondpad/"
+      - "cp {{.OPENROAD_FLOW_ROOT}}/platforms/ihp-sg13g2/gds/bondpad_70x70.gds {{ .BUILD_ROOT }}/{{ .SOC }}/{{ .board }}/zibal/macros/bondpad/"
+      # TODO: wait until sg13cmos5l is public and bondpad.py got fixed
+      #- task: lib-bondpad
+      #  vars:
+      #    board: "{{.TECH}}"
 
   simulate:
     desc: Runs simulations at the RTL level. Add 'duration=n' to specify the duration in n milliseconds.
     cmds:
       - task: lib-simulate
         vars:
-          board: "SG13G2"
+          board: "{{.TECH}}"
 
   view-simulation:
     desc: Opens the simulation with GTKWave.
     cmds:
       - task: lib-view-simulation
         vars:
-          board: "SG13G2"
+          board: "{{.TECH}}"
 
   layout:
     desc: Creates the physical layout of the chip.
     cmds:
       - task: lib-layout
         vars:
-          board: "SG13G2"
+          board: "{{.TECH}}"
 
   filler:
     desc: Inserts filler cells into the layout to ensure proper chip functionality.
     cmds:
       - task: lib-filler
         vars:
-          board: "SG13G2"
+          board: "{{.TECH}}"
 
   run-drc:
     desc: Performs Design Rule Checks and reports violations; use 'level=minimal' for a basic check.
     cmds:
       - task: lib-run-drc
         vars:
-          board: "SG13G2"
+          board: "{{.TECH}}"
 
   view-drc:
     desc: Displays DRC results in KLayout; 'level=minimal' opens minimal deck results.
     cmds:
       - task: lib-view-drc
         vars:
-          board: "SG13G2"
+          board: "{{.TECH}}"
 
   view-openroad:
     desc: Loads the layout into OpenROAD for further analysis or modification.
     cmds:
       - task: lib-view-openroad
         vars:
-          board: "SG13G2"
+          board: "{{.TECH}}"
 
   view-klayout:
     desc: Opens the chip layout in KLayout for inspection.
     cmds:
       - task: lib-view-klayout
         vars:
-          board: "SG13G2"
+          board: "{{.TECH}}"
 
   check-logs:
     desc: Checks the build directory for warnings or errors in the logs.
     cmds:
       - task: lib-check-logs
         vars:
-          board: "SG13G2"
+          board: "{{.TECH}}"
 
   default:
     desc: Executes the full IHP SG13G2 RTL-to-GDSII flow and validates the layout afterwards.

--- a/hardware/scala/i2cgpioexpander/SG13CMOS5L/SG13CMOS5L.scala
+++ b/hardware/scala/i2cgpioexpander/SG13CMOS5L/SG13CMOS5L.scala
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: 2026 aesc silicon
+//
+// SPDX-License-Identifier: CERN-OHL-W-2.0
+
+package i2cgpioexpander
+import spinal.core._
+import spinal.core.sim._
+import spinal.lib._
+
+import nafarr.blackboxes.ihp.sg13cmos5l._
+
+import zibal.misc.OpenROADTools
+
+import elements.sdk.ElementsApp
+
+case class SG13CMOS5LTop(p: I2cGpioExpander.Parameter, resetDelay: Int) extends Component {
+  val io = new Bundle {
+    val clock = IhpCmosIo("south", 0)
+    val reset = IhpCmosIo("south", 1, "clk_core")
+    val i2c = new Bundle {
+      val scl = IhpCmosIo("south", 2, "clk_core")
+      val sda = IhpCmosIo("south", 3, "clk_core")
+      val interrupt = IhpCmosIo("south", 4, "clk_core")
+    }
+    val gpio = Vec(
+      IhpCmosIo("north", 0, "clk_core"),
+      IhpCmosIo("north", 1, "clk_core"),
+      IhpCmosIo("north", 2, "clk_core"),
+      IhpCmosIo("north", 3, "clk_core"),
+      IhpCmosIo("north", 4, "clk_core"),
+      IhpCmosIo("west", 0, "clk_core"),
+      IhpCmosIo("west", 1, "clk_core"),
+      IhpCmosIo("west", 2, "clk_core")
+    )
+    val address = Vec(
+      IhpCmosIo("east", 2, "clk_core"),
+      IhpCmosIo("east", 3, "clk_core"),
+      IhpCmosIo("east", 4, "clk_core")
+    )
+  }
+  val clock = Bool
+  val reset = Bool
+  val address = Bits(io.address.length bits)
+
+  io.clock <> IOPadIn(clock)
+  io.reset <> IOPadIn(reset)
+  for (index <- 0 until io.address.length) {
+    io.address(index) <> IOPadIn(address(index))
+  }
+
+  val clockCtrl = new Area {
+    val mainClockDomain = ClockDomain(
+      clock = clock,
+      reset = reset,
+      frequency = FixedFrequency(50 MHz),
+      config = ClockDomainConfig(resetKind = spinal.core.SYNC, resetActiveLevel = LOW)
+    )
+  }
+  val system = new ClockingArea(clockCtrl.mainClockDomain) {
+    val expander = I2cGpioExpander(p)
+    expander.io.address := address
+  }
+
+  io.i2c.interrupt <> IOPadOut4mA(system.expander.io.i2c.interrupts(0))
+  io.i2c.scl <> IOPadInOut4mA(system.expander.io.i2c.scl)
+  io.i2c.sda <> IOPadInOut4mA(system.expander.io.i2c.sda)
+  for (index <- 0 until io.gpio.length) {
+    io.gpio(index) <> IOPadInOut16mA(system.expander.io.gpio.pins(index))
+  }
+}
+object SG13CMOS5LGenerate extends ElementsApp {
+  val report = elementsConfig.genASICSpinalConfig.generateVerilog {
+    val top = SG13CMOS5LTop(I2cGpioExpander.Parameter.default.copy(addressWidth = 3), 128)
+    top
+  }
+
+  val chip = OpenROADTools.IHP.Config(elementsConfig, OpenROADTools.PDKs.IHP.sg13cmos5l)
+  chip.dieArea = (0, 0, 1050.24, 1050.84)
+  chip.coreArea = (351.36, 351.54, 699.84, 699.3)
+  chip.hasIoRing = true
+  chip.addClock(report.toplevel.io.clock.PAD, 50 MHz, "clk_core")
+  chip.io = Some(report.toplevel.io)
+  chip.pdnRingWidth = 8.0
+  chip.pdnRingSpace = 5.0
+  chip.addPad("east", 0, "sg13cmos5l_IOPadVdd")
+  chip.addPad("east", 1, "sg13cmos5l_IOPadVss")
+  chip.addPad("west", 3, "sg13cmos5l_IOPadIOVss")
+  chip.addPad("west", 4, "sg13cmos5l_IOPadIOVdd")
+  chip.generate
+}

--- a/manifest-nightly.xml
+++ b/manifest-nightly.xml
@@ -11,8 +11,8 @@ SPDX-License-Identifier: CERN-OHL-W-2.0
 
 	<default remote="github" sync-j="8" />
 
-	<project name="aesc-silicon/elements-nafarr" path="modules/elements/nafarr" revision="ec37d766b941caa5699897a5dfc4ef08ac42744e" />
-	<project name="aesc-silicon/elements-zibal" path="modules/elements/zibal" revision="f25e5cd5458fbb99195fa8a0168a13a715df3cd5" />
+	<project name="aesc-silicon/elements-nafarr" path="modules/elements/nafarr" revision="7bbe873489c34796ac27df2b44ff4a5e1a57063e" />
+	<project name="aesc-silicon/elements-zibal" path="modules/elements/zibal" revision="7650f577706ed1937efebd18f47c70ab9fb9ccf1" />
 	<project name="SpinalHDL/SpinalCrypto" path="modules/elements/SpinalCrypto" revision="f2a4ae9db5e9434c5589d0651efec8719103498e" />
 	<project name="aesc-silicon/elements-vexriscv" path="modules/elements/vexriscv" revision="7f2bccbef256b3ad40fb8dc8ba08a266f9c6256b" />
 	<project name="The-OpenROAD-Project/OpenROAD-flow-scripts" path="tools/OpenROAD-flow-scripts" revision="master" />

--- a/manifest.xml
+++ b/manifest.xml
@@ -11,10 +11,10 @@ SPDX-License-Identifier: CERN-OHL-W-2.0
 
 	<default remote="github" sync-j="8" />
 
-	<project name="aesc-silicon/elements-nafarr" path="modules/elements/nafarr" revision="ec37d766b941caa5699897a5dfc4ef08ac42744e" />
-	<project name="aesc-silicon/elements-zibal" path="modules/elements/zibal" revision="f25e5cd5458fbb99195fa8a0168a13a715df3cd5" />
+	<project name="aesc-silicon/elements-nafarr" path="modules/elements/nafarr" revision="7bbe873489c34796ac27df2b44ff4a5e1a57063e" />
+	<project name="aesc-silicon/elements-zibal" path="modules/elements/zibal" revision="7650f577706ed1937efebd18f47c70ab9fb9ccf1" />
 	<project name="SpinalHDL/SpinalCrypto" path="modules/elements/SpinalCrypto" revision="f2a4ae9db5e9434c5589d0651efec8719103498e" />
 	<project name="aesc-silicon/elements-vexriscv" path="modules/elements/vexriscv" revision="7f2bccbef256b3ad40fb8dc8ba08a266f9c6256b" />
-	<project name="The-OpenROAD-Project/OpenROAD-flow-scripts" path="tools/OpenROAD-flow-scripts" revision="a53c2e0d12c70105245f203d555f9628c71f245a" />
-	<project name="IHP-GmbH/IHP-Open-PDK" sync-s="true" path="pdks/IHP-Open-PDK" revision="bbee036961439743e598a13674fac2f10d43cc4d" />
+	<project name="The-OpenROAD-Project/OpenROAD-flow-scripts" path="tools/OpenROAD-flow-scripts" revision="cc3eba7744b76ebe4c864d20a735e07bd7d357c6" />
+	<project name="IHP-GmbH/IHP-Open-PDK" sync-s="true" path="pdks/IHP-Open-PDK" revision="49c4047e946f03328896b6276fe5acded45a6cd2" />
 </manifest>

--- a/podman-compose-headless.yml
+++ b/podman-compose-headless.yml
@@ -10,7 +10,7 @@ volumes:
   cache:
 services:
   elements:
-    image: docker.io/dnltz/elements:v2.0
+    image: docker.io/dnltz/elements:v2.1
     container_name: i2c-gpio-expander_container
     environment:
       - DISPLAY=${DISPLAY}

--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -10,7 +10,7 @@ volumes:
   cache:
 services:
   elements:
-    image: docker.io/dnltz/elements:v2.0
+    image: docker.io/dnltz/elements:v2.1
     container_name: i2c-gpio-expander_container
     environment:
       - DISPLAY=${DISPLAY}


### PR DESCRIPTION
Rework the Taskfile to easily switch between different PDKs. Also add a ihp-sg13cmos5l version of the i2c-gpio-expander.