### PR TITLE
Fix bondpad workaround and GPIO order

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -115,9 +115,9 @@ tasks:
       - task: lib-sealring
         vars:
           board: "{{.TECH}}"
-      - "mkdir -p {{ .BUILD_ROOT }}/{{ .SOC }}/{{ .board }}/zibal/macros/bondpad"
-      - "cp {{.OPENROAD_FLOW_ROOT}}/platforms/ihp-sg13g2/lef/bondpad_70x70.lef {{ .BUILD_ROOT }}/{{ .SOC }}/{{ .board }}/zibal/macros/bondpad/"
-      - "cp {{.OPENROAD_FLOW_ROOT}}/platforms/ihp-sg13g2/gds/bondpad_70x70.gds {{ .BUILD_ROOT }}/{{ .SOC }}/{{ .board }}/zibal/macros/bondpad/"
+      - "mkdir -p {{ .BUILD_ROOT }}/{{ .SOC }}/{{ .TECH }}/zibal/macros/bondpad"
+      - "cp {{.OPENROAD_FLOW_ROOT}}/platforms/ihp-sg13g2/lef/bondpad_70x70.lef {{ .BUILD_ROOT }}/{{ .SOC }}/{{ .TECH }}/zibal/macros/bondpad/"
+      - "cp {{.OPENROAD_FLOW_ROOT}}/platforms/ihp-sg13g2/gds/bondpad_70x70.gds {{ .BUILD_ROOT }}/{{ .SOC }}/{{ .TECH }}/zibal/macros/bondpad/bondpad_70x70.gds.gz"
       # TODO: wait until sg13cmos5l is public and bondpad.py got fixed
       #- task: lib-bondpad
       #  vars:

--- a/hardware/scala/i2cgpioexpander/SG13CMOS5L/SG13CMOS5L.scala
+++ b/hardware/scala/i2cgpioexpander/SG13CMOS5L/SG13CMOS5L.scala
@@ -23,14 +23,14 @@ case class SG13CMOS5LTop(p: I2cGpioExpander.Parameter, resetDelay: Int) extends 
       val interrupt = IhpCmosIo("south", 4, "clk_core")
     }
     val gpio = Vec(
+      IhpCmosIo("west", 0, "clk_core"),
+      IhpCmosIo("west", 1, "clk_core"),
+      IhpCmosIo("west", 2, "clk_core"),
       IhpCmosIo("north", 0, "clk_core"),
       IhpCmosIo("north", 1, "clk_core"),
       IhpCmosIo("north", 2, "clk_core"),
       IhpCmosIo("north", 3, "clk_core"),
-      IhpCmosIo("north", 4, "clk_core"),
-      IhpCmosIo("west", 0, "clk_core"),
-      IhpCmosIo("west", 1, "clk_core"),
-      IhpCmosIo("west", 2, "clk_core")
+      IhpCmosIo("north", 4, "clk_core")
     )
     val address = Vec(
       IhpCmosIo("east", 2, "clk_core"),

--- a/hardware/scala/i2cgpioexpander/SG13G2/SG13G2.scala
+++ b/hardware/scala/i2cgpioexpander/SG13G2/SG13G2.scala
@@ -23,14 +23,14 @@ case class SG13G2Top(p: I2cGpioExpander.Parameter, resetDelay: Int) extends Comp
       val interrupt = IhpCmosIo("south", 4, "clk_core")
     }
     val gpio = Vec(
+      IhpCmosIo("west", 0, "clk_core"),
+      IhpCmosIo("west", 1, "clk_core"),
+      IhpCmosIo("west", 2, "clk_core"),
       IhpCmosIo("north", 0, "clk_core"),
       IhpCmosIo("north", 1, "clk_core"),
       IhpCmosIo("north", 2, "clk_core"),
       IhpCmosIo("north", 3, "clk_core"),
-      IhpCmosIo("north", 4, "clk_core"),
-      IhpCmosIo("west", 0, "clk_core"),
-      IhpCmosIo("west", 1, "clk_core"),
-      IhpCmosIo("west", 2, "clk_core")
+      IhpCmosIo("north", 4, "clk_core")
     )
     val address = Vec(
       IhpCmosIo("east", 2, "clk_core"),


### PR DESCRIPTION
1. Order GPIO pins that they appear as GPIO 0-7 in the pin-out table, which is organized from clock-wise.
2. Copy existing bondpad files into the correct directory and rename the gds file to gds.gz. This macro will be replaced by the 'bonpad.py' script in the future as soon as the script is fully implemented.
