### PR TITLE
Add manifest-tapeout-ihp-sg13cmos5l-2026-03-r1.xml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,13 +37,15 @@ script:
     if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then
       BRANCH="main"
       NIGHTLY="nightly=1"
+      MANIFEST_SUFFIX="manifest_suffix=-nightly"
     else
       BRANCH="${TRAVIS_PULL_REQUEST_BRANCH:-main}"
       NIGHTLY=""
+      MANIFEST_SUFFIX=""
     fi
 
   # Prepare the project
-  - task install branch=${BRANCH} ${NIGHTLY}
+  - task install branch=${BRANCH} ${NIGHTLY} ${MANIFEST_SUFFIX}
 
   # Prepare files
   - IS_HEADLESS=true task prepare

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -56,7 +56,7 @@ tasks:
       - venv/bin/pip3 install podman-compose==1.0.6
       - curl https://storage.googleapis.com/git-repo-downloads/repo > repo
       - chmod a+rx repo
-      - ./repo init -u https://github.com/aesc-silicon/i2c-gpio-expander.git -b {{if .branch}}{{.branch}}{{else}}main{{end}} -m manifest{{if .nightly}}-nightly{{end}}.xml
+      - ./repo init -u https://github.com/aesc-silicon/i2c-gpio-expander.git -b {{if .branch}}{{.branch}}{{else}}main{{end}} -m manifest{{.manifest_suffix}}.xml
 
   _build-container:
     desc: Creates a container with all necessary host requirements pre-installed.
@@ -75,6 +75,7 @@ tasks:
       - task: repo-sync
     vars:
       branch: "main"
+      manifest_suffix: ""
       nightly: "false"
 
   prepare:

--- a/manifest-tapeout-ihp-sg13cmos5l-2026-03-r1.xml
+++ b/manifest-tapeout-ihp-sg13cmos5l-2026-03-r1.xml
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='UTF-8'?>
+
+<!--
+SPDX-FileCopyrightText: 2026 aesc silicon
+
+SPDX-License-Identifier: CERN-OHL-W-2.0
+-->
+
+<manifest>
+	<remote fetch="https://github.com" name="github" />
+
+	<default remote="github" sync-j="8" />
+
+	<project name="aesc-silicon/elements-nafarr" path="modules/elements/nafarr" revision="tapeout-ihp-sg13cmos5l-2026-03-r1" />
+	<project name="aesc-silicon/elements-zibal" path="modules/elements/zibal" revision="tapeout-ihp-sg13cmos5l-2026-03-r1" />
+	<project name="SpinalHDL/SpinalCrypto" path="modules/elements/SpinalCrypto" revision="f2a4ae9db5e9434c5589d0651efec8719103498e" />
+	<project name="aesc-silicon/elements-vexriscv" path="modules/elements/vexriscv" revision="tapeout-ihp-sg13cmos5l-2026-03-r1" />
+	<project name="aesc-silicon/OpenROAD-flow-scripts" path="tools/OpenROAD-flow-scripts" revision="tapeout-ihp-sg13cmos5l-2026-03-r1" />
+	<project name="aesc-silicon/IHP-Open-PDK" sync-s="true" path="pdks/IHP-Open-PDK" revision="tapeout-ihp-sg13cmos5l-2026-03-r1" />
+</manifest>


### PR DESCRIPTION
- Initial tape-out targeting the IHP SG13CMOS5L PDK.
- IO placement optimized for cleaner PCB fanout:
  - Relocated `IOVss`/`IOVdd` power pins.
  - Consolidated and reordered all GPIO pins into a contiguous block.